### PR TITLE
kantex-rs 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,14 +783,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kantex-rs"
-version = "0.1.0"
-source = "git+https://github.com/sabbyX/KanTeX.git#f17586cb2c69ab22b446d30cfa08217cbd72c3bb"
-dependencies = [
- "strfmt",
-]
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,7 +1689,7 @@ dependencies = [
  "grammers-mtsender",
  "grammers-session",
  "grammers-tl-types",
- "kantex-rs 0.1.0 (git+https://github.com/sabbyX/KanTeX.git)",
+ "kantex-rs",
  "log",
  "rust-ini",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "kantex-rs"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "strfmt",
 ]

--- a/crates/kantex-rs/Cargo.toml
+++ b/crates/kantex-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kantex-rs"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["sabby <sabby.6@outlook.com>"]
 edition = "2018"
 

--- a/crates/kantex-rs/src/base.rs
+++ b/crates/kantex-rs/src/base.rs
@@ -1,10 +1,10 @@
 
 // TODO: rather use trait Into<String> instead of implementing our own
-pub trait Stringify: Send + Sync {
+pub trait Stringify: StringifyClone + Send + Sync {
     fn stringify(&self) -> String;
 }
 
-impl Stringify for &str {
+impl Stringify for &'static str {
     fn stringify(&self) -> String {
         self.to_string()
     }
@@ -13,5 +13,24 @@ impl Stringify for &str {
 impl Stringify for String {
     fn stringify(&self) -> String {
         self.clone()
+    }
+}
+
+pub trait StringifyClone {
+    fn clone_box(&self) -> Box<dyn Stringify>;
+}
+
+impl<T> StringifyClone for T
+    where
+        T: 'static + Stringify + Clone
+{
+    fn clone_box(&self) -> Box<dyn Stringify> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn Stringify> {
+    fn clone(&self) -> Self {
+        self.clone_box()
     }
 }

--- a/crates/kantex-rs/src/document.rs
+++ b/crates/kantex-rs/src/document.rs
@@ -32,3 +32,5 @@ impl Default for Document {
         Self::new()
     }
 }
+
+crate::implement_to_string!(Document);

--- a/crates/kantex-rs/src/document.rs
+++ b/crates/kantex-rs/src/document.rs
@@ -1,4 +1,5 @@
 use super::base::Stringify;
+use crate::__kantex_implement_to_string;
 
 #[derive(Clone)]
 pub struct Document {
@@ -34,7 +35,7 @@ impl Default for Document {
     }
 }
 
-crate::implement_to_string!{ Document }
+__kantex_implement_to_string!{ Document }
 
 mod tests {
     #[test]

--- a/crates/kantex-rs/src/document.rs
+++ b/crates/kantex-rs/src/document.rs
@@ -33,4 +33,4 @@ impl Default for Document {
     }
 }
 
-crate::implement_to_string!(Document);
+crate::implement_to_string!{ Document }

--- a/crates/kantex-rs/src/document.rs
+++ b/crates/kantex-rs/src/document.rs
@@ -1,5 +1,6 @@
 use super::base::Stringify;
 
+#[derive(Clone)]
 pub struct Document {
     sections: Vec<Box<dyn Stringify + 'static>>
 }
@@ -10,9 +11,9 @@ impl Document {
             sections: Vec::new(),
         }
     }
-    pub fn add_section<T: Stringify + 'static>(mut self, section: T) -> Self {
+    pub fn add_section<T: Stringify + 'static>(&mut self, section: T) -> Self {
         self.sections.push(Box::new(section));
-        self
+        self.clone()
     }
 }
 
@@ -34,3 +35,39 @@ impl Default for Document {
 }
 
 crate::implement_to_string!{ Document }
+
+mod tests {
+    #[test]
+    fn test_doc() {
+        use crate::{Document, Sections};
+
+        let expected = "<b>title</b>\n    key\n\n<b>title</b>\n    key";
+        let actual = Document::new()
+            .add_section(
+                Sections::new("title")
+                    .include("key")
+            )
+            .add_section(
+                Sections::new("title")
+                    .include("key")
+            );
+        assert_eq!(actual.to_string(), expected);
+    }
+
+    #[test]
+    fn test_doc_non_inline() {
+        use crate::{Document, Sections};
+
+        let expected = "<b>title</b>\n    key\n\n<b>title</b>\n    key";
+        let mut doc = Document::new();
+        doc.add_section(
+            Sections::new("title")
+                .include("key")
+        );
+        doc.add_section(
+            Sections::new("title")
+                .include("key")
+        );
+        assert_eq!(doc.to_string(), expected);
+    }
+}

--- a/crates/kantex-rs/src/items.rs
+++ b/crates/kantex-rs/src/items.rs
@@ -42,3 +42,8 @@ impl Stringify for KeyValueItem {
         format!("{}{} {}", self.key, KEY_VALUE_DELIM, self.value)
     }
 }
+
+crate::implement_to_string!(
+    MentionLink<'_>,
+    KeyValueItem
+);

--- a/crates/kantex-rs/src/items.rs
+++ b/crates/kantex-rs/src/items.rs
@@ -2,24 +2,24 @@ use super::{base::Stringify, styles::FormattedText};
 
 const KEY_VALUE_DELIM: char = ':';
 
-#[derive(Copy, Clone)]
-pub struct MentionLink<'life> {
-    label: &'life str,
+#[derive(Clone)]
+pub struct MentionLink {
+    label: String,
     uid: i32,
 }
 
-impl<'life> MentionLink<'life> {
-    pub fn new(label: &'life str, uid: i32) -> Self {
+impl MentionLink {
+    pub fn new(label: &str, uid: i32) -> Self {
         Self {
-            label,
+            label: label.into(),
             uid
         }
     }
 }
 
-impl Stringify for MentionLink<'static> {
+impl Stringify for MentionLink {
     fn stringify(&self) -> String {
-        FormattedText::hyperlink(self.label, format!("tg://user?id={}", self.uid).as_str())
+        FormattedText::hyperlink(self.label.as_str(), format!("tg://user?id={}", self.uid).as_str())
     }
 }
 
@@ -44,7 +44,7 @@ impl Stringify for KeyValueItem {
     }
 }
 
-crate::implement_to_string!{ MentionLink<'static> KeyValueItem }
+crate::implement_to_string!{ MentionLink KeyValueItem }
 
 mod tests {
 

--- a/crates/kantex-rs/src/items.rs
+++ b/crates/kantex-rs/src/items.rs
@@ -1,4 +1,5 @@
 use super::{base::Stringify, styles::FormattedText};
+use crate::__kantex_implement_to_string;
 
 const KEY_VALUE_DELIM: char = ':';
 
@@ -44,7 +45,7 @@ impl Stringify for KeyValueItem {
     }
 }
 
-crate::implement_to_string!{ MentionLink KeyValueItem }
+__kantex_implement_to_string!{ MentionLink KeyValueItem }
 
 mod tests {
 

--- a/crates/kantex-rs/src/items.rs
+++ b/crates/kantex-rs/src/items.rs
@@ -17,12 +17,13 @@ impl<'life> MentionLink<'life> {
     }
 }
 
-impl Stringify for MentionLink<'_> {
+impl Stringify for MentionLink<'static> {
     fn stringify(&self) -> String {
         FormattedText::hyperlink(self.label, format!("tg://user?id={}", self.uid).as_str())
     }
 }
 
+#[derive(Clone)]
 pub struct KeyValueItem {
     key: String,
     value: String,
@@ -43,4 +44,25 @@ impl Stringify for KeyValueItem {
     }
 }
 
-crate::implement_to_string!{ MentionLink<'_> KeyValueItem }
+crate::implement_to_string!{ MentionLink<'static> KeyValueItem }
+
+mod tests {
+
+    #[test]
+    fn test_key_value() {
+        use crate::KeyValueItem;
+
+        let expected = "key: value";
+        let actual = KeyValueItem::new("key", "value");
+        assert_eq!(actual.to_string(), expected)
+    }
+
+    #[test]
+    fn test_mention_link() {
+        use crate::MentionLink;
+
+        let expected = r##"<a href="tg://user?id=0">user</a>"##;
+        let actual = MentionLink::new("user", 0);
+        assert_eq!(actual.to_string(), expected);
+    }
+}

--- a/crates/kantex-rs/src/items.rs
+++ b/crates/kantex-rs/src/items.rs
@@ -43,7 +43,4 @@ impl Stringify for KeyValueItem {
     }
 }
 
-crate::implement_to_string!(
-    MentionLink<'_>,
-    KeyValueItem
-);
+crate::implement_to_string!{ MentionLink<'_> KeyValueItem }

--- a/crates/kantex-rs/src/lib.rs
+++ b/crates/kantex-rs/src/lib.rs
@@ -3,7 +3,9 @@ mod items;
 mod sections;
 mod styles;
 mod base;
+mod macros;
 
-pub use {document::Document, items::{MentionLink, KeyValueItem}, sections::{Sections, SubSections, SubSubSections},
-    styles::FormattedText, base::Stringify
+pub use {
+    document::Document, items::{MentionLink, KeyValueItem},
+    sections::{Sections, SubSections, SubSubSections}, styles::FormattedText
 };

--- a/crates/kantex-rs/src/macros.rs
+++ b/crates/kantex-rs/src/macros.rs
@@ -1,7 +1,7 @@
 
 #[macro_export]
 /// Macro to implement [`ToString`] for kantex-rs items
-macro_rules! implement_to_string {
+macro_rules! __kantex_implement_to_string {
     ($( $types:ty )*) => (
         $(
             impl ToString for $types {
@@ -14,7 +14,7 @@ macro_rules! implement_to_string {
 }
 
 #[macro_export]
-macro_rules! implement_add_trait {
+macro_rules! __kantex_implement_add_trait {
     ($($type:ty)*) => (
         $(
             impl std::ops::Add for $type {
@@ -28,7 +28,7 @@ macro_rules! implement_add_trait {
 }
 
 #[macro_export]
-macro_rules! implement_stringify {
+macro_rules! __kantex_implement_stringify {
     ($type:ty, $indent:literal) => {
         impl crate::base::Stringify for $type {
             fn stringify(&self) -> std::string::String {

--- a/crates/kantex-rs/src/macros.rs
+++ b/crates/kantex-rs/src/macros.rs
@@ -1,0 +1,14 @@
+
+#[macro_export]
+/// Macro to implement [`ToString`] for kantex-rs items
+macro_rules! implement_to_string {
+    ($( $types:ty ),*) => (
+        $(
+            impl ToString for $types {
+                fn to_string(&self) -> String {
+                    self.stringify()
+                }
+            }
+        )*
+    )
+}

--- a/crates/kantex-rs/src/macros.rs
+++ b/crates/kantex-rs/src/macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 /// Macro to implement [`ToString`] for kantex-rs items
 macro_rules! implement_to_string {
-    ($( $types:ty ),*) => (
+    ($( $types:ty )*) => (
         $(
             impl ToString for $types {
                 fn to_string(&self) -> String {
@@ -11,4 +11,37 @@ macro_rules! implement_to_string {
             }
         )*
     )
+}
+
+#[macro_export]
+macro_rules! implement_add_trait {
+    ($($type:ty)*) => (
+        $(
+            impl std::ops::Add for $type {
+                type Output = Self;
+                fn add(self, rhs: Self) -> Self {
+                    self.include(rhs)
+                }
+            }
+        )*
+    );
+}
+
+#[macro_export]
+macro_rules! implement_stringify {
+    ($type:ty, $indent:literal) => {
+        impl crate::base::Stringify for $type {
+            fn stringify(&self) -> std::string::String {
+                let mut item_list: Vec<String> = Vec::new();
+                for i in &self.items {
+                    let mut text = i.stringify();
+                    text.insert_str(0, " ".repeat($indent).as_str());
+                    item_list.push(text);
+                }
+                let header = FormattedText::bold(self.header.as_str());
+                item_list.insert(0, header);
+                item_list.join("\n")
+            }
+        }
+    };
 }

--- a/crates/kantex-rs/src/macros.rs
+++ b/crates/kantex-rs/src/macros.rs
@@ -19,7 +19,7 @@ macro_rules! implement_add_trait {
         $(
             impl std::ops::Add for $type {
                 type Output = Self;
-                fn add(self, rhs: Self) -> Self {
+                fn add(mut self, rhs: Self) -> Self {
                     self.include(rhs)
                 }
             }

--- a/crates/kantex-rs/src/sections.rs
+++ b/crates/kantex-rs/src/sections.rs
@@ -92,8 +92,13 @@ impl Stringify for SubSubSections {
 
 impl SubSubSections {
     pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
-        // let text = WHITESPACE.repeat(SUB_SUB_SECTION_INDET) + &*text.into();
         self.items.push(Box::new(text));
         self
     }
 }
+
+crate::implement_to_string!(
+    Sections,
+    SubSections,
+    SubSubSections
+);

--- a/crates/kantex-rs/src/sections.rs
+++ b/crates/kantex-rs/src/sections.rs
@@ -1,5 +1,6 @@
 use super::{base::Stringify, styles::FormattedText};
 
+#[derive(Clone)]
 pub struct Sections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>
@@ -13,14 +14,15 @@ impl Sections {
         }
     }
 
-    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
+    pub fn include<T: Stringify + 'static>(&mut self, text: T) -> Self {
         self.items.push(Box::new(text));
-        self
+        self.clone()
     }
 }
 
 crate::implement_stringify!{ Sections, 4 }
 
+#[derive(Clone)]
 pub struct SubSections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>
@@ -34,28 +36,90 @@ impl SubSections {
         }
     }
 
-    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
+    pub fn include<T: Stringify + 'static>(&mut self, text: T) -> Self {
         self.items.push(Box::new(text));
-        self
+        self.clone()
     }
 }
 
 crate::implement_stringify!{ SubSections, 8 }
 
+#[derive(Clone)]
 pub struct SubSubSections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>,
 }
 
 impl SubSubSections {
-    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
+
+    pub fn new(header: &str) -> Self {
+        Self {
+            header: header.to_owned(),
+            items: Vec::new(),
+        }
+    }
+
+    pub fn include<T: Stringify + 'static>(&mut self, text: T) -> Self {
         self.items.push(Box::new(text));
-        self
+        self.clone()
     }
 }
 
-crate::implement_stringify!{ SubSubSections, 8 }
+crate::implement_stringify!{ SubSubSections, 12 }
 
 // auto impl
 crate::implement_to_string!{ Sections SubSections SubSubSections }
 crate::implement_add_trait!{ Sections SubSections SubSubSections }
+
+mod tests {
+    #[test]
+    fn test_section() {
+        use crate::Sections;
+        //                                  ---- 4
+        let expected = "<b>title</b>\n    key";
+        let actual = Sections::new("title")
+            .include("key");
+        assert_eq!(actual.to_string(), expected)
+    }
+
+    #[test]
+    fn test_sub_section() {
+        use crate::{Sections, SubSections};
+        //                                  ---- 4            -------- 8
+        let expected = "<b>title</b>\n    <b>title</b>\n        key";
+        let actual = Sections::new("title")
+            .include(
+                SubSections::new("title")
+                    .include("key")
+            );
+        assert_eq!(actual.to_string(), expected)
+    }
+
+    #[test]
+    fn test_sub_sub_section() {
+        use crate::{Sections, SubSections, SubSubSections};
+
+        //                                  ---- 4            -------- 8            ------------ 12
+        let expected = "<b>title</b>\n    <b>title</b>\n        <b>title</b>\n            key";
+        let actual = Sections::new("title")
+            .include(
+                SubSections::new("title")
+                    .include(
+                        SubSubSections::new("title")
+                            .include("key")
+                    )
+            );
+        assert_eq!(actual.to_string(), expected)
+    }
+
+    #[test]
+    fn test_sections_non_inline() {
+        use crate::Sections;
+
+        let expected = "<b>title</b>\n    key\n    key";
+        let mut section = Sections::new("title");
+        section.include("key");
+        section.include("key");
+        assert_eq!(section.to_string(), expected);
+    }
+}

--- a/crates/kantex-rs/src/sections.rs
+++ b/crates/kantex-rs/src/sections.rs
@@ -1,4 +1,5 @@
 use super::{base::Stringify, styles::FormattedText};
+use crate::{__kantex_implement_stringify, __kantex_implement_to_string, __kantex_implement_add_trait};
 
 #[derive(Clone)]
 pub struct Sections {
@@ -20,7 +21,7 @@ impl Sections {
     }
 }
 
-crate::implement_stringify!{ Sections, 4 }
+__kantex_implement_stringify!{ Sections, 4 }
 
 #[derive(Clone)]
 pub struct SubSections {
@@ -42,7 +43,7 @@ impl SubSections {
     }
 }
 
-crate::implement_stringify!{ SubSections, 8 }
+__kantex_implement_stringify!{ SubSections, 8 }
 
 #[derive(Clone)]
 pub struct SubSubSections {
@@ -65,11 +66,11 @@ impl SubSubSections {
     }
 }
 
-crate::implement_stringify!{ SubSubSections, 12 }
+__kantex_implement_stringify!{ SubSubSections, 12 }
 
 // auto impl
-crate::implement_to_string!{ Sections SubSections SubSubSections }
-crate::implement_add_trait!{ Sections SubSections SubSubSections }
+__kantex_implement_to_string!{ Sections SubSections SubSubSections }
+__kantex_implement_add_trait!{ Sections SubSections SubSubSections }
 
 mod tests {
     #[test]

--- a/crates/kantex-rs/src/sections.rs
+++ b/crates/kantex-rs/src/sections.rs
@@ -1,10 +1,5 @@
 use super::{base::Stringify, styles::FormattedText};
 
-const SECTION_INDENT: usize = 4;
-const SUB_SECTION_INDENT: usize = 8;
-const SUB_SUB_SECTION_INDENT: usize = 12;
-const WHITESPACE: &str = " ";
-
 pub struct Sections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>
@@ -24,37 +19,11 @@ impl Sections {
     }
 }
 
-impl Stringify for Sections {
-    fn stringify(&self) -> String {
-        let mut list: Vec<String> = Vec::new();
-        for i in &self.items {
-            let mut text = i.stringify();
-            text.insert_str(0, &*WHITESPACE.repeat(SECTION_INDENT));
-            list.push(text);
-        }
-        let header = FormattedText::bold(&*self.header);
-        list.insert(0, header);
-        list.join("\n")
-    }
-}
+crate::implement_stringify!{ Sections, 4 }
 
 pub struct SubSections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>
-}
-
-impl Stringify for SubSections {
-    fn stringify(&self) -> String {
-        let mut list: Vec<String> = Vec::new();
-        for i in &self.items {
-            let mut text = i.stringify();
-            text.insert_str(0, &*WHITESPACE.repeat(SUB_SECTION_INDENT));
-            list.push(text);
-        }
-        let header = FormattedText::bold(&*self.header);
-        list.insert(0, header);
-        list.join("\n")
-    }
 }
 
 impl SubSections {
@@ -71,23 +40,11 @@ impl SubSections {
     }
 }
 
+crate::implement_stringify!{ SubSections, 8 }
+
 pub struct SubSubSections {
     header: String,
     items: Vec<Box<dyn Stringify + 'static>>,
-}
-
-impl Stringify for SubSubSections {
-    fn stringify(&self) -> String {
-        let mut list: Vec<String> = Vec::new();
-        for i in &self.items {
-            let mut text = i.stringify();
-            text.insert_str(0, &*WHITESPACE.repeat(SUB_SUB_SECTION_INDENT));
-            list.push(text);
-        }
-        let header = FormattedText::bold(&*self.header);
-        list.insert(0, header);
-        list.join("\n")
-    }
 }
 
 impl SubSubSections {
@@ -97,8 +54,8 @@ impl SubSubSections {
     }
 }
 
-crate::implement_to_string!(
-    Sections,
-    SubSections,
-    SubSubSections
-);
+crate::implement_stringify!{ SubSubSections, 8 }
+
+// auto impl
+crate::implement_to_string!{ Sections SubSections SubSubSections }
+crate::implement_add_trait!{ Sections SubSections SubSubSections }

--- a/crates/kantex-rs/src/sections.rs
+++ b/crates/kantex-rs/src/sections.rs
@@ -1,10 +1,8 @@
-// TODO:
-#![allow(clippy::should_implement_trait)]
 use super::{base::Stringify, styles::FormattedText};
 
 const SECTION_INDENT: usize = 4;
 const SUB_SECTION_INDENT: usize = 8;
-const SUB_SUB_SECTION_INDET: usize = 12;
+const SUB_SUB_SECTION_INDENT: usize = 12;
 const WHITESPACE: &str = " ";
 
 pub struct Sections {
@@ -19,7 +17,8 @@ impl Sections {
             items: Vec::new(),
         }
     }
-    pub fn add<T: Stringify + 'static>(mut self, text: T) -> Self {
+
+    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
         self.items.push(Box::new(text));
         self
     }
@@ -66,7 +65,7 @@ impl SubSections {
         }
     }
 
-    pub fn add<T: Stringify + 'static>(mut self, text: T) -> Self {
+    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
         self.items.push(Box::new(text));
         self
     }
@@ -82,7 +81,7 @@ impl Stringify for SubSubSections {
         let mut list: Vec<String> = Vec::new();
         for i in &self.items {
             let mut text = i.stringify();
-            text.insert_str(0, &*WHITESPACE.repeat(SUB_SUB_SECTION_INDET));
+            text.insert_str(0, &*WHITESPACE.repeat(SUB_SUB_SECTION_INDENT));
             list.push(text);
         }
         let header = FormattedText::bold(&*self.header);
@@ -92,7 +91,7 @@ impl Stringify for SubSubSections {
 }
 
 impl SubSubSections {
-    pub fn add<T: Stringify + 'static>(mut self, text: T) -> Self {
+    pub fn include<T: Stringify + 'static>(mut self, text: T) -> Self {
         // let text = WHITESPACE.repeat(SUB_SUB_SECTION_INDET) + &*text.into();
         self.items.push(Box::new(text));
         self

--- a/crates/kantex-rs/src/styles.rs
+++ b/crates/kantex-rs/src/styles.rs
@@ -41,7 +41,7 @@ impl<'a> Default for Entities<'a> {
                 italics: Tags::new("__", "__"),
                 underline: Tags::new("--", "--"),
                 strikethrough: Tags::new("~~", "~~"),
-                hyperlink: "[{}]({})",
+                hyperlink: "[{label}]({url})",
                 monospace: Tags::new("`", "`"),
             }
         } else {
@@ -50,7 +50,7 @@ impl<'a> Default for Entities<'a> {
                 italics: Tags::new("<i>", "</i>"),
                 underline: Tags::new("<u>", "</u>"),
                 strikethrough: Tags::new("<s>", "</s>"),
-                hyperlink: "<a href=\"{}\">{}</a>",
+                hyperlink: "<a href=\"{url}\">{label}</a>",
                 monospace: Tags::new("<code>", "</code>")
             }
         }

--- a/crates/kantex-rs/src/styles.rs
+++ b/crates/kantex-rs/src/styles.rs
@@ -22,6 +22,7 @@ pub(crate) struct Entities<'a> {
     pub(crate) underline: Tags<'a>,
     pub(crate) strikethrough: Tags<'a>,
     pub(crate) hyperlink: &'a str,
+    pub(crate) monospace: Tags<'a>,
 }
 
 impl<'a> Entities<'a> {
@@ -41,6 +42,7 @@ impl<'a> Default for Entities<'a> {
                 underline: Tags::new("--", "--"),
                 strikethrough: Tags::new("~~", "~~"),
                 hyperlink: "[{}]({})",
+                monospace: Tags::new("`", "`"),
             }
         } else {
             Entities {
@@ -49,6 +51,7 @@ impl<'a> Default for Entities<'a> {
                 underline: Tags::new("<u>", "</u>"),
                 strikethrough: Tags::new("<s>", "</s>"),
                 hyperlink: "<a href=\"{}\">{}</a>",
+                monospace: Tags::new("<code>", "</code>")
             }
         }
     }
@@ -85,5 +88,10 @@ impl FormattedText {
         vars.insert("label".to_string(), label.to_string());
         entities.hyperlink.format(&vars)
             .unwrap_or_else(|_| "<Failed to create mention link>".to_string())
+    }
+
+    pub fn monospace(text: &str) -> String {
+        let entities = Entities::new();
+        entities.monospace.start.to_string() + text + entities.monospace.end
     }
 }

--- a/crates/userbot-rs/src/modules/info.rs
+++ b/crates/userbot-rs/src/modules/info.rs
@@ -65,6 +65,6 @@ pub async fn alive_command(mut message: Message, _: UpdateData,) -> Result<()> {
                 versions::GRAMMERS_VERSION,
             )),
     );
-    message.reply(InputMessage::html(text.stringify())).await?;
+    message.reply(InputMessage::html(text.to_string())).await?;
     Ok(())
 }

--- a/crates/userbot-rs/src/modules/info.rs
+++ b/crates/userbot-rs/src/modules/info.rs
@@ -55,12 +55,12 @@ pub async fn alive_command(mut message: Message, _: UpdateData,) -> Result<()> {
     if args.update {}
     let text = Document::new().add_section(
         Sections::new("Userbot")
-            .add(FormattedText::bold("github.com/sabbyX/userbot-rs"))
-            .add(KeyValueItem::new(
+            .include(FormattedText::bold("github.com/sabbyX/userbot-rs"))
+            .include(KeyValueItem::new(
                 FormattedText::bold("version"),
                 env!("CARGO_PKG_VERSION"),
             ))
-            .add(KeyValueItem::new(
+            .include(KeyValueItem::new(
                 FormattedText::bold("grammers"),
                 versions::GRAMMERS_VERSION,
             )),

--- a/crates/userbot-rs/src/modules/ping.rs
+++ b/crates/userbot-rs/src/modules/ping.rs
@@ -21,7 +21,7 @@ use grammers_client::InputMessage;
 use grammers_tl_types as tl;
 use std::time;
 use userbot_rs_macros::handler;
-use kantex_rs::{Document, Sections, FormattedText, Stringify};
+use kantex_rs::{Document, Sections, FormattedText};
 use anyhow::Result;
 use crate::modules::core::UpdateData;
 
@@ -49,7 +49,8 @@ pub async fn ping(mut message: Message, mut data: UpdateData,) -> Result<()> {
                 .add_section(
                     Sections::new("Pong")
                         .include(FormattedText::italics(ping_.as_str()))
-                ).stringify()
+                )
+                .to_string()
         )).await?;
     }
     Ok(())

--- a/crates/userbot-rs/src/modules/ping.rs
+++ b/crates/userbot-rs/src/modules/ping.rs
@@ -48,7 +48,7 @@ pub async fn ping(mut message: Message, mut data: UpdateData,) -> Result<()> {
             Document::new()
                 .add_section(
                     Sections::new("Pong")
-                        .add(FormattedText::italics(ping_.as_str()))
+                        .include(FormattedText::italics(ping_.as_str()))
                 ).stringify()
         )).await?;
     }

--- a/crates/userbot-rs/src/modules/process.rs
+++ b/crates/userbot-rs/src/modules/process.rs
@@ -4,7 +4,7 @@ use userbot_rs_macros::handler;
 use clap::{Clap, AppSettings, ArgSettings};
 use grammers_client::{types::Message, InputMessage};
 use tokio::process::Command;
-use kantex_rs::{Document, Sections, FormattedText, KeyValueItem, Stringify};
+use kantex_rs::{Document, Sections, FormattedText, KeyValueItem};
 use which::which;
 use std::ffi::OsStr;
 use crate::modules::core::UpdateData;
@@ -53,7 +53,7 @@ pub async fn process_command(mut message: Message, _: UpdateData) -> Result<()> 
                             Sections::new("Stdout")
                                 .include(String::from_utf8_lossy(&output.stdout).to_string())
                         )
-                        .stringify()
+                        .to_string()
                 )
             )
                 .await?

--- a/crates/userbot-rs/src/modules/process.rs
+++ b/crates/userbot-rs/src/modules/process.rs
@@ -43,15 +43,15 @@ pub async fn process_command(mut message: Message, _: UpdateData) -> Result<()> 
                     Document::new()
                         .add_section(
                             Sections::new("Output")
-                                .add(KeyValueItem::new(FormattedText::bold("Exit Code"), output.status.code().unwrap_or(1).to_string()))
+                                .include(KeyValueItem::new(FormattedText::bold("Exit Code"), output.status.code().unwrap_or(1).to_string()))
                         )
                         .add_section(
                             Sections::new("Stderr")
-                                .add(String::from_utf8_lossy(&output.stderr).to_string())
+                                .include(String::from_utf8_lossy(&output.stderr).to_string())
                         )
                         .add_section(
                             Sections::new("Stdout")
-                                .add(String::from_utf8_lossy(&output.stdout).to_string())
+                                .include(String::from_utf8_lossy(&output.stdout).to_string())
                         )
                         .stringify()
                 )


### PR DESCRIPTION
## TODOs
- [x] Rename `add` function to `include`
- [x] Impl `std::ops::Add` for sections
- [ ] ~Better integration with grammers~
- [x] Use traits other than `Stringify` ( upd: internally, we still use `Stringify` trait)
- [ ] ~Add documentation to methods~ (#45)
- [x] Add tests
- [x] Support for non-inline inclusion of items